### PR TITLE
use `click` instead of `mouseup`

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -169,8 +169,6 @@ window.jQuery = window.jQuery || window.shoestring;
 	};
 
 	menu.prototype.init = function(){
-		var self = this;
-
 		// prevent re-init
 		if( this.$element.data( componentName ) ) {
 			return;

--- a/src/menu.js
+++ b/src/menu.js
@@ -169,6 +169,8 @@ window.jQuery = window.jQuery || window.shoestring;
 	};
 
 	menu.prototype.init = function(){
+		var self = this;
+
 		// prevent re-init
 		if( this.$element.data( componentName ) ) {
 			return;
@@ -179,11 +181,11 @@ window.jQuery = window.jQuery || window.shoestring;
 		this.close();
 		var self = this;
 
-		// close on any click, even on the menu
-		// NOTE we can't close on `mouseup` in case there's overflow scrolling
-		// because the `mouseup` event is fired when using the scrollbar
-		$( document ).bind( "click", function(){
-			self.close();
+		$( document ).bind( "mouseup", function(event){
+			// only close the menu if the click is outside the menu element
+			if( ! $(event.target).closest( self.$element[0] ).length ){
+				self.close();
+			}
 		});
 
 		this._bindKeyHandling();

--- a/src/menu.js
+++ b/src/menu.js
@@ -180,9 +180,11 @@ window.jQuery = window.jQuery || window.shoestring;
 		var self = this;
 
 		// close on any click, even on the menu
-		$( document ).bind( "mouseup", function(){
+		// NOTE we can't close on `mouseup` in case there's overflow scrolling
+		// because the `mouseup` event is fired when using the scrollbar
+		$( document ).bind( "click", function(){
 			self.close();
-		} );
+		});
 
 		this._bindKeyHandling();
 


### PR DESCRIPTION
This is one part of addressing issue #12 for the auto-complete
component. Using `mouseup` closes the menu when the user is done
scrolling if there is overflow in the menu element.
