### PR TITLE
correct close -> open -> close behavior with the trigger

### DIFF
--- a/src/menu-trigger.js
+++ b/src/menu-trigger.js
@@ -45,15 +45,28 @@
 				.bind( "input keydown", function( e ){
 					self.menu.keyDown( e );
 				})
-				.bind( "focus click", function(){
-					if( this.value !== "" ){
+				.bind( "focus click", function(event){
+					if( this.value !== "" && self.isInMenu(event.relatedTarget) ) {
 						self.menu.open();
 					}
-				} )
-				.bind( "blur", function(){
-					self.menu.close();
+				})
+				.bind( "blur", function(event){
+					if( self.isInMenu(event.relatedTarget) ){
+						self.menu.close();
+					}
 				});
 		}
+
+		$(window.document).bind("focus", function(event){
+			return;
+			if(!$(event.target).closest( this.$menu[0] ).length){
+				self.menu.close();
+			}
+		});
+	};
+
+	Menutrigger.prototype.isInMenu = function(element){
+		return !$(element).closest( this.$menu[0] ).length;
 	};
 
 	Menutrigger.prototype.init = function(){

--- a/src/menu.js
+++ b/src/menu.js
@@ -143,6 +143,7 @@ window.jQuery = window.jQuery || window.shoestring;
 		if( this.opened ){
 			return;
 		}
+
 		this.$element.attr( at.ariaHidden, false );
 
 		this.$element.data( componentName + "-trigger", trigger );
@@ -181,8 +182,12 @@ window.jQuery = window.jQuery || window.shoestring;
 
 		// close on any click, even on the menu
 		$( document ).bind( "mouseup", function(){
-			self.close();
-		} );
+			// let the selectActive close do the work of closing the menu
+			// when the menu itself is clicked
+			if( !$(event.target).closest(self.$element[0]).length ){
+				self.close();
+			}
+		});
 
 		this._bindKeyHandling();
 


### PR DESCRIPTION
Corrects an issue with trigger where the focus bindings in the menu trigger were closing and then reopening the menu before the `selectActive` method had a chance to execute. The reopening reset the active element to the first list element preventing a user clicking on the menu item from getting the value they selected.
